### PR TITLE
update minimum cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.1)
+cmake_minimum_required(VERSION 3.10)
 
 set (PROJECT libb64)
 project (${PROJECT})


### PR DESCRIPTION
support for cmake 2.8.1 is deprecated and will be removed, it will be nice to update the min version to not have the warning be more future-proof